### PR TITLE
Removed recursive link

### DIFF
--- a/docs/introduction/how-it-came-to-be.md
+++ b/docs/introduction/how-it-came-to-be.md
@@ -28,8 +28,6 @@ From the Spec-Up documentation: “*Spec-Up* is a technical specification develo
 | [Spec-Up on Github](https://github.com/decentralized-identity/spec-up) | [Spec-Up-T on Github](https://github.com/trustoverip/spec-up-t) |
 | [DIF website](https://identity.foundation/)  | [ToIP website](https://trustoverip.org/)  |
 
-*Spec-Up-T* is an expansion of [DIF's Spec-Up](https://github.com/decentralized-identity/spec-up) specifically for the needs of the Trust-over-IP foundation. Read more in the elaborate motivation in this technical article: [How it came to be](how-it-came-to-be.md).
-
 ## Spec-Up-T
 
 Spec-Up-T stays in sync with Spec-Up and currently adds the following extra functionality:


### PR DESCRIPTION
We're on "How it came to be" page. And right there we say "learn more on \"How it came to be\"" page. But we're already there. The removed line is a copypaste from the spec-up-and-spec-up-t.md page. It works there, but here it summarizes what's been said above and self-references, which is weird.